### PR TITLE
fix compatibility with anki 25

### DIFF
--- a/ankiExcelSync/auto.py
+++ b/ankiExcelSync/auto.py
@@ -1,25 +1,7 @@
-from anki.hooks import addHook
-from aqt.main import AnkiQt
-from aqt import mw
+from aqt import gui_hooks, mw
 from aqt.utils import showText
 from .sync import ExcelSync
 from .menu import confirm_a2e_sync
-
-
-def sync_launch(self, onsuccess=None):
-    self.loadCollection()
-    try:
-        ExcelSync()._e2a_sync()
-    except Exception as e:
-        showText(str(e))
-
-    # from method aqt.AnkiQt.unloadCollection
-    def callback():
-        self.setEnabled(False)
-        self._unloadCollection()
-        self.aes_old_load_profile(onsuccess)
-
-    self.closeAllWindows(callback)
 
 
 def sync_close():
@@ -29,11 +11,15 @@ def sync_close():
 def onlaunch():
     config = mw.addonManager.getConfig(__name__)
     if config["autosync_on_launch"]:
-        AnkiQt.aes_old_load_profile = AnkiQt.loadProfile
-        AnkiQt.loadProfile = sync_launch
+        def _run_e2a():
+            try:
+                ExcelSync()._e2a_sync()
+            except Exception as e:
+                showText(str(e))
+        gui_hooks.profile_did_open.append(_run_e2a)
 
 
 def setclose():
     config = mw.addonManager.getConfig(__name__)
     if config["autosync_on_close"]:
-        addHook("unloadProfile", sync_close)
+        gui_hooks.profile_will_close.append(sync_close)

--- a/ankiExcelSync/menu.py
+++ b/ankiExcelSync/menu.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import QAction
+from aqt.qt import QAction
 from aqt import mw
 from aqt.utils import askUserDialog
 

--- a/ankiExcelSync/sync.py
+++ b/ankiExcelSync/sync.py
@@ -1,10 +1,10 @@
 import os
 import unicodedata
-import urllib.parse
 import re
 from operator import itemgetter
 
-from anki import version as ankiversion
+from anki.decks import DeckId
+from anki.notes import NoteFieldsCheckResult
 from aqt import mw
 from aqt.editor import Editor
 from aqt.utils import showText
@@ -13,9 +13,6 @@ from .excel import ExcelFile
 from .errors import *
 from .menu import confirm_win
 from .template import EditorTemplate
-
-ankiver_minor = int(ankiversion.split(".")[2])
-ankiver_major = ankiversion[0:3]
 
 
 class ExcelSync:
@@ -78,18 +75,7 @@ class ExcelSync:
         return (file_list, super_tags)
 
     def prepare_field_val(self, txt):
-        # from Editor.onBridgeCmd
-        if ankiver_minor <= 19:
-            txt = urllib.parse.unquote(txt)
-        if ankiver_minor <= 27:
-            # after v28, normalization optionally occurs when saving note data
-            txt = unicodedata.normalize("NFC", txt)
-        if ankiver_minor <= 29:
-            # after v30, occurs upon calling mungeHtml
-            txt = txt.replace("\x00", "")
-            txt = mw.col.media.escapeImages(txt, unescape=True)
-
-        editor_templ = EditorTemplate()  # esp for editor.mw reference
+        editor_templ = EditorTemplate()
         txt = Editor.mungeHTML(editor_templ, txt)
         return txt
 
@@ -147,7 +133,7 @@ class ExcelSync:
                     note.tags.remove(tag)
         otag = unicodedata.normalize("NFC", otag)
         note.tags += mw.col.tags.canonify([otag])
-        note.flush()
+        mw.col.update_note(note)
 
     def create_note(self, note_data, tag, decknm):
         """
@@ -158,12 +144,11 @@ class ExcelSync:
         row = note_data["row"]
         model_name = note_data["model"]
 
-        model = mw.col.models.byName(model_name)  # Returns None when not exist
+        model = mw.col.models.by_name(model_name)  # Returns None when not exist
         if not model:  # check if model doesn't exist
             raise ModelNameDoesNotExistError(fpath, model_name)
 
-        mw.col.models.setCurrent(model)
-        note = mw.col.newNote(forDeck=False)
+        note = mw.col.new_note(model)
         # check if fldnm not exist in model
         nflds = note.keys()
         for fldnm in note_data[
@@ -178,40 +163,33 @@ class ExcelSync:
             note[fldnm] = fldval
         tag = unicodedata.normalize("NFC", tag)
         note.tags = mw.col.tags.canonify([tag])
-        did = mw.col.decks.byName(decknm)[
-            "id"
-        ]  # decknm is already validated in a2e_sync
-        note.model()["did"] = did
+        did = DeckId(mw.col.decks.by_name(decknm)["id"])  # decknm is already validated in a2e_sync
 
         # Check if note is valid, from method aqt.addCards.addNote
-        ret = note.dupeOrEmpty()
-        if ret == 1:
+        ret = note.fields_check()
+        if ret == NoteFieldsCheckResult.EMPTY:
             self.log.extend(
                 (
                     "Non-fatal: Note skipped because first field is empty."
                     "Please sync again after fixing this issue.",
-                    "From row: {}, file: {}".join(note_data["row"], note_data["path"]),
+                    "From row: {}, file: {}".format(note_data["row"], note_data["path"]),
                 )
             )
             return None
 
-        if "{{cloze:" in note.model()["tmpls"][0]["qfmt"]:
-            if not mw.col.models._availClozeOrds(
-                note.model(), note.joinedFields(), False
-            ):
-                self.log.extend(
-                    (
-                        "Non-fatal: No cloze exist in cloze note type.",
-                        "Note was still added.",
-                        "From row: {}, file: {}".format(
-                            note_data["row"], note_data["path"]
-                        ),
-                    )
+        if ret == NoteFieldsCheckResult.MISSING_CLOZE:
+            self.log.extend(
+                (
+                    "Non-fatal: No cloze exist in cloze note type.",
+                    "Note was still added.",
+                    "From row: {}, file: {}".format(
+                        note_data["row"], note_data["path"]
+                    ),
                 )
+            )
 
-        cards = mw.col.addNote(note)
-        if not cards:
-
+        out = mw.col.add_note(note, did)
+        if not out.count:
             self.log.extend(
                 (
                     "NON-fatal: No cards are made from this note.",
@@ -227,10 +205,10 @@ class ExcelSync:
     def get_remove_cards_id(self, super_tags, note_ids):
         del_ids = []
         for tag in super_tags:
-            card_ids = mw.col.findCards("tag:" + tag + "::*")
-            card_ids.extend(mw.col.findCards("tag:" + tag))
+            card_ids = mw.col.find_cards("tag:" + tag + "::*")
+            card_ids.extend(mw.col.find_cards("tag:" + tag))
             for card_id in card_ids:
-                if mw.col.getCard(card_id).nid not in note_ids:
+                if mw.col.get_card(card_id).nid not in note_ids:
                     del_ids.append(card_id)
         return del_ids
 
@@ -238,7 +216,7 @@ class ExcelSync:
         models_all = mw.col.models.all()
         models = []
         for mdl in models_all:
-            mdlcount = mw.col.models.useCount(mdl)
+            mdlcount = mw.col.models.use_count(mdl)
             fields = []
             for fld in mdl["flds"]:
                 fields.append(fld["name"])
@@ -294,8 +272,8 @@ class ExcelSync:
                 note_data["tag"] = tag
                 if note_data["id"]:
                     note_id = note_data["id"]
-                    if mw.col.findNotes("nid:%s" % note_id):
-                        note = mw.col.getNote(note_id)
+                    if mw.col.find_notes("nid:%s" % note_id):
+                        note = mw.col.get_note(note_id)
                         note_data["exist"] = True
                         exist_note_ids.append(note_id)
                         if not self.same_note(note, note_data, tag, super_tags):
@@ -338,7 +316,7 @@ class ExcelSync:
             # Check if valid
             if dirc == "Z:/Somedirectory you want to save excel files":
                 raise DidNotConfigureDirectoryError()
-            if not mw.col.decks.byName(decknm):
+            if not mw.col.decks.by_name(decknm):
                 raise DeckNameDoesNotExistError(decknm)
 
             # Get all excel file names and supertags
@@ -385,7 +363,7 @@ class ExcelSync:
                     )
                 note_id = note_data["id"]
                 tag = note_data["tag"]
-                note = mw.col.getNote(note_id)
+                note = mw.col.get_note(note_id)
                 self.sync_note(note, note_data, tag, super_tags)
                 cnt += 1
 
@@ -412,7 +390,7 @@ class ExcelSync:
                     ef.close()
 
             # Delete cards
-            mw.col.remCards(del_ids)
+            mw.col.remove_cards_and_orphaned_notes(del_ids)
 
             self.log.extend(
                 (
@@ -463,10 +441,10 @@ class ExcelSync:
             mw.progress.update(label="Going through all the cards")
 
             for tag in super_tags:
-                card_ids = mw.col.findCards("tag:" + tag + "::*")
-                card_ids.extend(mw.col.findCards("tag:" + tag))
+                card_ids = mw.col.find_cards("tag:" + tag + "::*")
+                card_ids.extend(mw.col.find_cards("tag:" + tag))
                 for card_id in card_ids:
-                    card = mw.col.getCard(card_id)
+                    card = mw.col.get_card(card_id)
                     note = card.note()
                     note_tag = None
                     for t in note.tags:


### PR DESCRIPTION
Fix compatibility with Anki 25.x (PyQt6 + snake_case API migration)

The plugin has been broken since Anki's backend rewrite (~2.1.45) and Qt6 migration (~2.1.50). This PR updates it to work with modern Anki (tested on 25.09.2). Compatibility is maintained back to approximately 2.1.50. Older pyqt5 and older API versions are unsupported.

Changes:

menu.py 
- from PyQt5.QtWidgets import QAction → from aqt.qt import QAction (PyQt6)

auto.py
- Replaced monkey-patching of AnkiQt.loadProfile and addHook("unloadProfile") with gui_hooks.profile_did_open / gui_hooks.profile_will_close, which are the supported addon hooks for these lifecycle events 

sync.py 
- Removed version-gated compatibility shims in prepare_field_val (those code paths were dead on any newer version of Anki)
- Updated entire collection API from camelCase to snake_case: getNote → get_note, getCard → get_card,
findCards → find_cards, findNotes → find_notes, remCards → remove_cards_and_orphaned_notes
- models.byName/setCurrent/useCount → by_name/use_count; newNote(forDeck=False) → new_note(model) 
- addNote(note) → add_note(note, DeckId(did)) (deck ID is now passed explicitly) 
- note.flush() → mw.col.update_note(note) 
- note.dupeOrEmpty() + manual cloze check → note.fields_check() with NoteFieldsCheckResult enum 
(handles MISSING_CLOZE state directly)
- decks.byName → decks.by_name